### PR TITLE
Add version output

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,11 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser
+    - -s -w
+    - -X github.com/tedsmitt/ecsgo/pkg/cmd.version={{.Version}}
+    - -X github.com/tedsmitt/ecsgo/pkg/cmd.commit={{.Commit}}
+    - -X github.com/tedsmitt/ecsgo/pkg/cmd.date={{ .CommitDate }}
+    - -X github.com/tedsmitt/ecsgo/pkg/cmd.builtBy=goreleaser
 changelog:
   sort: asc
   filters:

--- a/pkg/cmd/internal.go
+++ b/pkg/cmd/internal.go
@@ -26,6 +26,11 @@ var (
 	red    = color.New(color.FgRed).SprintFunc()
 	green  = color.New(color.FgGreen).SprintFunc()
 	yellow = color.New(color.FgYellow).SprintFunc()
+
+	version = "unset"
+	commit  = "unset"
+	date    = "unset"
+	builtBy = "unset"
 )
 
 func createEcsClient() *ecs.ECS {
@@ -308,6 +313,10 @@ func runCommand(process string, args ...string) error {
 	}
 
 	return nil
+}
+
+func getVersion() string {
+	return fmt.Sprintf("Version: %s, Commit: %s, Built date: %s, Built by: %s", version, commit, date, builtBy)
 }
 
 // selectProfile

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -43,6 +43,7 @@ of the ECS ExecuteCommand API under the hood.
 Requires pre-existing installation of the session-manager-plugin
 (https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
 ------------`,
+	Version: getVersion(),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createEcsClient()
 		if err := StartExecuteCommand(client); err != nil {


### PR DESCRIPTION
## What
Add version that will be shown when `--version` or `-v` is passed

```console
$ ecsgo --version
ecsgo version Version: v1.0.0, Commit: xxxxxx, Built date: 2021-03-10 18:10:30, Built by: goreleaser
```

## Why
To know which release am I using.