### PR TITLE
Remove CGO env from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,6 @@ before:
     - go mod tidy
 builds:
 - dir: cmd
-  env:
-    - CGO_ENABLED=0
   goos:
     - linux
     - darwin


### PR DESCRIPTION
## Why

From Go 1.16, cgo is disabled by default.  