### PR TITLE
Revert "Remove CGO env from goreleaser config"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,8 @@ before:
     - go mod tidy
 builds:
 - dir: cmd
+  env:
+    - CGO_ENABLED=0
   goos:
     - linux
     - darwin


### PR DESCRIPTION
## What

Sorry, I was misunderstanding. 
The cgo is not disabled by default, the go module was 😢 

Sorry, I want to revert it. Thank you in advance 🙇 