### PR TITLE
Default command for Windows or Linux

### DIFF
--- a/internal/exec.go
+++ b/internal/exec.go
@@ -69,7 +69,7 @@ func (e *ExecCommand) Start() {
 				case "getContainer":
 					e.getContainer()
 				case "executeCommand":
-					e.executeinput()
+					e.executeInput()
 				default:
 					e.getCluster()
 				}
@@ -253,9 +253,9 @@ func (e *ExecCommand) getContainer() {
 	}
 }
 
-// executeinput takes all of our previous values and builds a session for us
+// executeInput takes all of our previous values and builds a session for us
 // and then calls runCommand to execute the session input via session-manager-plugin
-func (e *ExecCommand) executeinput() {
+func (e *ExecCommand) executeInput() {
 	// Check if command has been passed to the tool, otherwise default to /bin/sh
 	var command string
 	if viper.GetString("cmd") != "" {

--- a/internal/exec_test.go
+++ b/internal/exec_test.go
@@ -66,7 +66,7 @@ func (m *MockECSAPI) ExecuteCommand(input *ecs.ExecuteCommandInput) (*ecs.Execut
 // CreateMockExecCommand initialises a new ExecCommand struct and takes a MockClient as an argument - only used in tests
 func CreateMockExecCommand(c *MockECSAPI) *ExecCommand {
 	e := &ExecCommand{
-		cmd:      make(chan string, 1),
+		input:    make(chan string, 1),
 		err:      make(chan error, 1),
 		done:     make(chan bool),
 		client:   c,
@@ -111,9 +111,9 @@ func TestGetCluster(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		cmd := CreateMockExecCommand(c.client)
-		cmd.getCluster()
-		assert.Equal(t, c.expected, cmd.cluster)
+		input := CreateMockExecCommand(c.client)
+		input.getCluster()
+		assert.Equal(t, c.expected, input.cluster)
 	}
 }
 
@@ -151,10 +151,10 @@ func TestGetService(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		cmd := CreateMockExecCommand(c.client)
-		cmd.cluster = "execCommand"
-		cmd.getService()
-		assert.Equal(t, c.expected, cmd.service)
+		input := CreateMockExecCommand(c.client)
+		input.cluster = "execCommand"
+		input.getService()
+		assert.Equal(t, c.expected, input.service)
 	}
 }
 
@@ -202,11 +202,11 @@ func TestGetTask(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		cmd := CreateMockExecCommand(c.client)
-		cmd.cluster = "execCommand"
-		cmd.service = "test-service-1"
-		cmd.getTask()
-		assert.Equal(t, c.expected, cmd.task)
+		input := CreateMockExecCommand(c.client)
+		input.cluster = "execCommand"
+		input.service = "test-service-1"
+		input.getTask()
+		assert.Equal(t, c.expected, input.task)
 	}
 }
 
@@ -251,9 +251,9 @@ func TestGetContainer(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		cmd := CreateMockExecCommand(c.client)
-		cmd.task = c.task
-		cmd.getContainer()
-		assert.Equal(t, c.expected, cmd.container)
+		input := CreateMockExecCommand(c.client)
+		input.task = c.task
+		input.getContainer()
+		assert.Equal(t, c.expected, input.container)
 	}
 }


### PR DESCRIPTION
- Add conditional to check the OS family and determine a sensible default command for Windows or Linux
- Rename "cmd" channel to "input" to avoid confusion with the arg "cmd"