### PR TITLE
Use simple comparision instead of Contains / fix #20

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -188,7 +188,7 @@ func selectContainer(containers []*ecs.Container) (*ecs.Container, error) {
 
 	var container *ecs.Container
 	for _, c := range containers {
-		if strings.Contains(*c.Name, selection) {
+		if selection == *c.Name {
 			container = c
 		}
 	}


### PR DESCRIPTION
When using `strings.Contains` our flow breaks when selecting the container - see issue https://github.com/tedsmitt/ecsgo/issues/20
The problem is we have 2 containers that are named like this
- sample-ui-logger
- sample-ui

I pick up the first `sample-ui`, but it ends up ssh into `sample-ui-logger`, because `.Contains` function will match both in that case.

Please check it out, not sure there is a specific reason for using `.Contains`