### PR TITLE
DRAFT: Fix/#21 platform family nil ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ You can also view some additional documentation on using ECS Exec [here](https:/
 
 ## Usage
 
-| Flag | Description                                                                                 | Default Value             |
-| ---- | --------------------------------------------------------------------------------------------| --------------------------|
-| `-p` | Specify the profile to load the credentials                                                 | `default`                 |
-| `-c` | Specify the command to be run on the container (default will change depending on OS family) | `/bin/sh`,`powershell.exe`|
-| `-r` | Specify the AWS region to run in                                                            | N/A                       |
+| Flag | Description                                                                                  | Default Value              |
+| ---- | -------------------------------------------------------------------------------------------- | -------------------------- |
+| `-p` | Specify the profile to load the credentials                                                  | `default`                  |
+| `-c` | Specify the command to be run on the container (default will change depending on OS family). | `/bin/sh`,`powershell.exe` |
+| `-r` | Specify the AWS region to run in                                                             | N/A                        |
 
 The tool also supports AWS Config/Environment Variables for configuration. If you aren't familiar with working on AWS via the CLI, you can read more about how to configure your environment [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 

--- a/internal/exec.go
+++ b/internal/exec.go
@@ -260,15 +260,16 @@ func (e *ExecCommand) getContainer() {
 // executeInput takes all of our previous values and builds a session for us
 // and then calls runCommand to execute the session input via session-manager-plugin
 func (e *ExecCommand) executeInput() {
-	// Check if command has been passed to the tool, otherwise default to /bin/sh
-	var command string
+	// Check if command has been passed to the tool, defaults to /bin/sh
+	command := "/bin/sh"
 	if viper.GetString("cmd") != "" {
 		command = viper.GetString("cmd")
 	} else {
-		if strings.Contains(*e.task.PlatformFamily, "Windows") {
-			command = "powershell.exe"
-		} else {
-			command = "/bin/sh"
+		// Check PlatformFamily value and change default cmd if required
+		if e.task.PlatformFamily != nil {
+			if strings.Contains(*e.task.PlatformFamily, "Windows") {
+				command = "powershell.exe"
+			}
 		}
 	}
 

--- a/internal/exec_test.go
+++ b/internal/exec_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/stretchr/testify/assert"
@@ -16,19 +18,20 @@ func init() {
 }
 
 type MockECSAPI struct {
-	ecsiface.ECSAPI    // embedding of the interface is needed to skip implementation of all methods
-	ListClustersMock   func(input *ecs.ListClustersInput) (*ecs.ListClustersOutput, error)
-	ListServicesMock   func(input *ecs.ListServicesInput) (*ecs.ListServicesOutput, error)
-	ListTasksMock      func(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
-	DescribeTasksMock  func(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
-	ExecuteCommandMock func(input *ecs.ExecuteCommandInput) (*ecs.ExecuteCommandOutput, error)
+	ecsiface.ECSAPI                // embedding of the interface is needed to skip implementation of all methods
+	ListClustersMock               func(input *ecs.ListClustersInput) (*ecs.ListClustersOutput, error)
+	ListServicesMock               func(input *ecs.ListServicesInput) (*ecs.ListServicesOutput, error)
+	ListTasksMock                  func(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
+	DescribeTasksMock              func(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
+	DescribeTaskDefinitionMock     func(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error)
+	DescribeContainerInstancesMock func(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error)
+	ExecuteCommandMock             func(input *ecs.ExecuteCommandInput) (*ecs.ExecuteCommandOutput, error)
 }
 
 func (m *MockECSAPI) ListClusters(input *ecs.ListClustersInput) (*ecs.ListClustersOutput, error) {
 	if m.ListClustersMock != nil {
 		return m.ListClustersMock(input)
 	}
-
 	return nil, nil
 }
 
@@ -36,7 +39,6 @@ func (m *MockECSAPI) ListServices(input *ecs.ListServicesInput) (*ecs.ListServic
 	if m.ListServicesMock != nil {
 		return m.ListServicesMock(input)
 	}
-
 	return nil, nil
 }
 
@@ -44,7 +46,6 @@ func (m *MockECSAPI) ListTasks(input *ecs.ListTasksInput) (*ecs.ListTasksOutput,
 	if m.ListTasksMock != nil {
 		return m.ListTasksMock(input)
 	}
-
 	return nil, nil
 }
 
@@ -52,7 +53,20 @@ func (m *MockECSAPI) DescribeTasks(input *ecs.DescribeTasksInput) (*ecs.Describe
 	if m.DescribeTasksMock != nil {
 		return m.DescribeTasksMock(input)
 	}
+	return nil, nil
+}
 
+func (m *MockECSAPI) DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
+	if m.DescribeTaskDefinitionMock != nil {
+		return m.DescribeTaskDefinitionMock(input)
+	}
+	return nil, nil
+}
+
+func (m *MockECSAPI) DescribeContainerInstances(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error) {
+	if m.DescribeContainerInstancesMock != nil {
+		return m.DescribeContainerInstancesMock(input)
+	}
 	return nil, nil
 }
 
@@ -60,7 +74,18 @@ func (m *MockECSAPI) ExecuteCommand(input *ecs.ExecuteCommandInput) (*ecs.Execut
 	if m.ExecuteCommandMock != nil {
 		return m.ExecuteCommandMock(input)
 	}
+	return nil, nil
+}
 
+type MockEC2API struct {
+	ec2iface.EC2API       // embedding of the interface is needed to skip implementation of all methods
+	DescribeInstancesMock func(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
+}
+
+func (m *MockEC2API) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	if m.DescribeInstancesMock != nil {
+		return m.DescribeInstancesMock(input)
+	}
 	return nil, nil
 }
 
@@ -198,14 +223,16 @@ func TestGetTask(t *testing.T) {
 					return &ecs.DescribeTasksOutput{
 						Tasks: []*ecs.Task{
 							{
-								TaskArn: aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
+								TaskArn:    aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
+								LaunchType: aws.String("FARGATE"),
 							},
 						},
 					}, nil
 				},
 			},
 			expected: &ecs.Task{
-				TaskArn: aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
+				TaskArn:    aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
+				LaunchType: aws.String("FARGATE"),
 			},
 		},
 		{
@@ -287,99 +314,25 @@ func TestGetContainer(t *testing.T) {
 func TestExecuteInput(t *testing.T) {
 	cases := []struct {
 		name     string
-		client   *MockECSAPI
 		expected error
+		client   *MockECSAPI
+		cluster  string
+		task     *ecs.Task
 	}{
 		{
-			name: "TestExecuteInputWithServices",
-			client: &MockECSAPI{
-				ListClustersMock: func(input *ecs.ListClustersInput) (*ecs.ListClustersOutput, error) {
-					return &ecs.ListClustersOutput{
-						ClusterArns: []*string{
-							aws.String("arn:aws:ecs:eu-west-1:1111111111:cluster/execCommand"),
-						},
-					}, nil
+			name:    "TestExecuteInput",
+			cluster: "test",
+			task: &ecs.Task{
+				TaskArn: aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
+				Containers: []*ecs.Container{
+					{
+						Name:      aws.String("nginx"),
+						RuntimeId: aws.String("544e08d919364be9926186b086c29868-2531612879"),
+					},
 				},
-				ListServicesMock: func(input *ecs.ListServicesInput) (*ecs.ListServicesOutput, error) {
-					return &ecs.ListServicesOutput{
-						ServiceArns: []*string{
-							aws.String("arn:aws:ecs:eu-west-1:1111111111:cluster/execCommand/test-service-1"),
-						},
-					}, nil
-				},
-				ListTasksMock: func(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
-					return &ecs.ListTasksOutput{
-						TaskArns: []*string{
-							aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
-						},
-					}, nil
-				},
-				DescribeTasksMock: func(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
-					return &ecs.DescribeTasksOutput{
-						Tasks: []*ecs.Task{
-							{
-								TaskArn: aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
-								Containers: []*ecs.Container{
-									{
-										Name:      aws.String("nginx"),
-										RuntimeId: aws.String("544e08d919364be9926186b086c29868-2531612879"),
-									},
-								},
-								PlatformFamily: aws.String("Linux"),
-							},
-						},
-					}, nil
-				},
-				ExecuteCommandMock: func(input *ecs.ExecuteCommandInput) (*ecs.ExecuteCommandOutput, error) {
-					return &ecs.ExecuteCommandOutput{
-						Session: &ecs.Session{
-							SessionId:  aws.String("ecs-execute-command-0e86561fddf625dc1"),
-							StreamUrl:  aws.String("wss://ssmmessages.eu-west-1.amazonaws.com/v1/data-channel/ecs-execute-command-blah"),
-							TokenValue: aws.String("abc123"),
-						},
-					}, nil
-				},
+				PlatformFamily: aws.String("Linux"),
 			},
-			expected: nil,
-		},
-		{
-			name: "TestExecuteInputWithNoServices",
 			client: &MockECSAPI{
-				ListClustersMock: func(input *ecs.ListClustersInput) (*ecs.ListClustersOutput, error) {
-					return &ecs.ListClustersOutput{
-						ClusterArns: []*string{
-							aws.String("arn:aws:ecs:eu-west-1:1111111111:cluster/execCommand"),
-						},
-					}, nil
-				},
-				ListServicesMock: func(input *ecs.ListServicesInput) (*ecs.ListServicesOutput, error) {
-					return &ecs.ListServicesOutput{
-						ServiceArns: []*string{},
-					}, nil
-				},
-				ListTasksMock: func(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
-					return &ecs.ListTasksOutput{
-						TaskArns: []*string{
-							aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
-						},
-					}, nil
-				},
-				DescribeTasksMock: func(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
-					return &ecs.DescribeTasksOutput{
-						Tasks: []*ecs.Task{
-							{
-								TaskArn: aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
-								Containers: []*ecs.Container{
-									{
-										Name:      aws.String("nginx"),
-										RuntimeId: aws.String("544e08d919364be9926186b086c29868-2531612879"),
-									},
-								},
-								PlatformFamily: aws.String("Linux"),
-							},
-						},
-					}, nil
-				},
 				ExecuteCommandMock: func(input *ecs.ExecuteCommandInput) (*ecs.ExecuteCommandOutput, error) {
 					return &ecs.ExecuteCommandOutput{
 						Session: &ecs.Session{
@@ -395,9 +348,128 @@ func TestExecuteInput(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		cmd := CreateMockExecCommand(c.client)
-		err := cmd.Start()
+		app := &ExecCommand{
+			input:    make(chan string, 1),
+			err:      make(chan error, 1),
+			exit:     make(chan error, 1),
+			client:   c.client,
+			region:   "eu-west-1",
+			endpoint: "ecs.eu-west-1.amazonaws.com",
+			cluster:  c.cluster,
+			task:     c.task,
+		}
+		app.container = c.task.Containers[0]
+		err := app.executeInput()
 		if ok := assert.Equal(t, c.expected, err); ok != true {
+			fmt.Printf("%s FAILED\n", c.name)
+		}
+		fmt.Printf("%s PASSED\n", c.name)
+	}
+}
+
+func TestGetPlatformFamily(t *testing.T) {
+	cases := []struct {
+		name      string
+		expected  string
+		ecsClient *MockECSAPI
+		cluster   string
+		task      *ecs.Task
+	}{
+		{
+			name:    "TestGetPlatformFamilyWithFargateTask",
+			cluster: "test",
+			task: &ecs.Task{
+				TaskArn:        aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
+				LaunchType:     aws.String("FARGATE"),
+				PlatformFamily: aws.String("Linux"),
+			},
+			ecsClient: &MockECSAPI{
+				DescribeTaskDefinitionMock: func(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
+					return &ecs.DescribeTaskDefinitionOutput{
+						TaskDefinition: &ecs.TaskDefinition{
+							RuntimePlatform: &ecs.RuntimePlatform{
+								OperatingSystemFamily: aws.String("Linux/UNIX"),
+							},
+						},
+					}, nil
+				},
+			},
+			expected: "Linux/UNIX",
+		},
+		{
+			name:    "TestGetPlatformFamilyWithEC2LaunchTaskNoRuntimePlatformFail",
+			cluster: "test",
+			task: &ecs.Task{
+				TaskArn:              aws.String("arn:aws:ecs:eu-west-1:111111111111:task/execCommand/8a58117dac38436ba5547e9da5d3ac3d"),
+				LaunchType:           aws.String("EC2"),
+				ContainerInstanceArn: aws.String("abcdefghij1234567890"),
+			},
+			ecsClient: &MockECSAPI{
+				DescribeTaskDefinitionMock: func(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
+					return &ecs.DescribeTaskDefinitionOutput{
+						TaskDefinition: &ecs.TaskDefinition{},
+					}, nil
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, c := range cases {
+		res, _ := getPlatformFamily(c.ecsClient, c.cluster, c.task)
+		if ok := assert.Equal(t, c.expected, res); ok != true {
+			fmt.Printf("%s FAILED\n", c.name)
+		}
+		fmt.Printf("%s PASSED\n", c.name)
+	}
+}
+
+func TestGetContainerInstanceOS(t *testing.T) {
+	cases := []struct {
+		name                 string
+		expected             string
+		ecsClient            *MockECSAPI
+		ec2Client            *MockEC2API
+		cluster              string
+		containerInstanceArn string
+	}{
+		{
+			name:                 "TestGetContainerInstanceOS",
+			cluster:              "test",
+			containerInstanceArn: "abcdef123456",
+			ecsClient: &MockECSAPI{
+				DescribeContainerInstancesMock: func(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error) {
+					return &ecs.DescribeContainerInstancesOutput{
+						ContainerInstances: []*ecs.ContainerInstance{
+							{
+								Ec2InstanceId: aws.String("i-0063cc3b62343f4d1"),
+							},
+						},
+					}, nil
+				},
+			},
+			ec2Client: &MockEC2API{
+				DescribeInstancesMock: func(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+					return &ec2.DescribeInstancesOutput{
+						Reservations: []*ec2.Reservation{
+							{
+								Instances: []*ec2.Instance{
+									{
+										InstanceId:      aws.String("i-0063cc3b62343f4d1"),
+										PlatformDetails: aws.String("Linux/UNIX"),
+									},
+								},
+							},
+						}}, nil
+				},
+			},
+			expected: "Linux/UNIX",
+		},
+	}
+
+	for _, c := range cases {
+		res, _ := getContainerInstanceOS(c.ecsClient, c.ec2Client, c.cluster, c.containerInstanceArn)
+		if ok := assert.Equal(t, c.expected, res); ok != true {
 			fmt.Printf("%s FAILED\n", c.name)
 		}
 		fmt.Printf("%s PASSED\n", c.name)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -11,9 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/fatih/color"
 	"github.com/spf13/viper"
 )
@@ -231,24 +229,4 @@ func runCommand(process string, args ...string) error {
 // getVersion returns version information
 func getVersion() string {
 	return fmt.Sprintf("Version: %s, Commit: %s, Built date: %s, Built by: %s", version, commit, date, builtBy)
-}
-
-func getContainerInstanceOs(ecsClient ecsiface.ECSAPI, ec2Client ec2iface.EC2API, cluster string, containerInstanceArn string) (*string, error) {
-	res, err := ecsClient.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
-		Cluster: aws.String(cluster),
-		ContainerInstances: []*string{
-			aws.String(containerInstanceArn),
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	instanceId := res.ContainerInstances[0].Ec2InstanceId
-	instance, err := ec2Client.DescribeInstances(&ec2.DescribeInstancesInput{
-		InstanceIds: []*string{
-			instanceId,
-		},
-	})
-	operatingSystem := instance.Reservations[0].Instances[0].PlatformDetails
-	return operatingSystem, nil
 }


### PR DESCRIPTION
Adds a check to the PlatformFamily value (only available on Fargate tasks) and if it is not available, then we get the container instance OS and add our own "PlatformFamily" value. This prevents the nil pointer issue we were seeing on EC2 launch-type tasks.